### PR TITLE
 Remove rmw_localhost_only_t & Add minor fixes

### DIFF
--- a/rmw_gurumdds_cpp/include/rmw_gurumdds_cpp/rmw_context_impl.hpp
+++ b/rmw_gurumdds_cpp/include/rmw_gurumdds_cpp/rmw_context_impl.hpp
@@ -71,7 +71,6 @@ struct rmw_context_impl_s
   dds_Publisher * publisher;
   dds_Subscriber * subscriber;
 
-  bool localhost_only;
   bool service_mapping_basic;
 
   /* Participant reference count */
@@ -91,7 +90,7 @@ struct rmw_context_impl_s
   // Initializes the participant, if it wasn't done already.
   // node_count is increased
   rmw_ret_t
-  initialize_node(const char * node_name, const char * node_namespace, const bool localhost_only);
+  initialize_node(const char * node_name, const char * node_namespace);
 
   // Destroys the participant, when node_count reaches 0.
   rmw_ret_t
@@ -99,10 +98,7 @@ struct rmw_context_impl_s
 
   // Initialize the DomainParticipant associated with the context.
   rmw_ret_t
-  initialize_participant(
-    const char * node_name,
-    const char * node_namespace,
-    const bool localhost_only);
+  initialize_participant(const char * node_name, const char * node_namespace);
 
   // Finalize the DomainParticipant associated with the context.
   rmw_ret_t

--- a/rmw_gurumdds_cpp/src/rmw_client.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_client.cpp
@@ -515,19 +515,19 @@ rmw_service_server_is_available(
   const rmw_client_t * client,
   bool * is_available)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node,
     node->implementation_identifier,
     RMW_GURUMDDS_ID,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     client,
     client->implementation_identifier,
     RMW_GURUMDDS_ID,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RMW_CHECK_ARGUMENT_FOR_NULL(is_available, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(is_available, RMW_RET_INVALID_ARGUMENT);
 
   auto client_info = static_cast<rmw_gurumdds_cpp::ClientInfo *>(client->data);
   if (client_info == nullptr) {

--- a/rmw_gurumdds_cpp/src/rmw_context_impl.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_context_impl.cpp
@@ -216,8 +216,7 @@ rmw_context_impl_s::rmw_context_impl_s(rmw_context_t* const base)
   domain_id(base->actual_domain_id),
   participant(nullptr),
   publisher(nullptr),
-  subscriber(nullptr),
-  localhost_only(base->options.localhost_only == RMW_LOCALHOST_ONLY_ENABLED)
+  subscriber(nullptr)
 {
   /* destructor relies on these being initialized properly */
   common_ctx.thread_is_running.store(false);
@@ -234,22 +233,9 @@ rmw_context_impl_s::~rmw_context_impl_s()
 }
 
 rmw_ret_t
-rmw_context_impl_s::initialize_node(
-  const char * node_name,
-  const char * node_namespace,
-  const bool localhost_only)
+rmw_context_impl_t::initialize_node(const char * node_name, const char * node_namespace)
 {
   if (this->node_count != 0u) {
-    if ((this->base->options.localhost_only == RMW_LOCALHOST_ONLY_ENABLED) != localhost_only)
-    {
-      RCUTILS_LOG_ERROR_NAMED(
-        RMW_GURUMDDS_ID,
-        "localhost_only option not matched, "
-        "ctx.localhost_only=%d, node.localhost_only=%d",
-        this->localhost_only, localhost_only);
-      return RMW_RET_ERROR;
-    }
-
     this->node_count += 1;
 
     RCUTILS_LOG_DEBUG_NAMED(
@@ -258,7 +244,7 @@ rmw_context_impl_s::initialize_node(
     return RMW_RET_OK;
   }
 
-  rmw_ret_t ret = this->initialize_participant(node_name, node_namespace, localhost_only);
+  rmw_ret_t ret = this->initialize_participant(node_name, node_namespace);
   if (ret != RMW_RET_OK) {
     RMW_SET_ERROR_MSG("failed to initialize DomainParticipant");
     return ret;
@@ -294,8 +280,7 @@ rmw_context_impl_s::finalize_node()
 rmw_ret_t
 rmw_context_impl_s::initialize_participant(
   const char * node_name,
-  const char * node_namespace,
-  const bool localhost_only)
+  const char * node_namespace)
 {
   dds_PublisherQos publisher_qos;
   dds_SubscriberQos subscriber_qos;
@@ -372,7 +357,8 @@ rmw_context_impl_s::initialize_participant(
   static_discovery_id += node_name;
 
   /* Create DomainParticipant */
-  if (localhost_only) {
+  if (RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST == this->base->options.discovery_options.automatic_discovery_range) {
+    // TODO: localhost only
     dds_StringProperty props[] = {
       {const_cast<char *>("rtps.interface.ip"),
         const_cast<void *>(static_cast<const void *>("127.0.0.1"))},

--- a/rmw_gurumdds_cpp/src/rmw_init.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_init.cpp
@@ -40,7 +40,6 @@ rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t all
   init_options->implementation_identifier = RMW_GURUMDDS_ID;
   init_options->domain_id = RMW_DEFAULT_DOMAIN_ID;
   init_options->security_options = rmw_get_zero_initialized_security_options();
-  init_options->localhost_only = RMW_LOCALHOST_ONLY_DEFAULT;
   init_options->enclave = nullptr;
   init_options->allocator = allocator;
   init_options->impl = nullptr;

--- a/rmw_gurumdds_cpp/src/rmw_node.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_node.cpp
@@ -93,9 +93,6 @@ rmw_create_node(
     return nullptr;
   }
 
-  bool node_localhost_only =
-    context->options.localhost_only == RMW_LOCALHOST_ONLY_ENABLED;
-
   rmw_context_impl_t * ctx = context->impl;
   std::lock_guard<std::mutex> guard(ctx->initialization_mutex);
 
@@ -104,7 +101,7 @@ rmw_create_node(
     return nullptr;
   }
 
-  ret = ctx->initialize_node(namespace_, name, node_localhost_only);
+  ret = ctx->initialize_node(namespace_, name);
   if (ret != RMW_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(RMW_GURUMDDS_ID, "failed to initialize node in context");
     return nullptr;

--- a/rmw_gurumdds_cpp/src/rmw_node.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_node.cpp
@@ -88,7 +88,7 @@ rmw_create_node(
     return nullptr;
   }
   if (RMW_NAMESPACE_VALID != validation_result) {
-    const char * reason = rmw_node_name_validation_result_string(validation_result);
+    const char * reason = rmw_namespace_validation_result_string(validation_result);
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("invalid node namespace: %s", reason);
     return nullptr;
   }

--- a/rmw_gurumdds_cpp/src/rmw_publisher.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_publisher.cpp
@@ -472,7 +472,7 @@ rmw_create_publisher(
     topic_name,
     &adapted_qos_policies,
     publisher_options,
-    ctx->localhost_only);
+    RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST == ctx->base->options.discovery_options.automatic_discovery_range);
 
   if (rmw_pub == nullptr) {
     RMW_SET_ERROR_MSG("failed to create RMW publisher");

--- a/rmw_gurumdds_cpp/src/rmw_subscription.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_subscription.cpp
@@ -653,7 +653,7 @@ rmw_create_subscription(
     topic_name,
     &adapted_qos_policies,
     subscription_options,
-    ctx->localhost_only);
+    RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST == ctx->base->options.discovery_options.automatic_discovery_range);
 
   if (rmw_sub == nullptr) {
     RMW_SET_ERROR_MSG("failed to create RMW subscription");

--- a/rmw_gurumdds_cpp/src/rmw_wait.cpp
+++ b/rmw_gurumdds_cpp/src/rmw_wait.cpp
@@ -108,7 +108,7 @@ fail:
 rmw_ret_t
 rmw_destroy_wait_set(rmw_wait_set_t * wait_set)
 {
-  RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     wait_set,
     wait_set->implementation_identifier,


### PR DESCRIPTION
This PR accomplishes the following:
* Remove `rmw_localhost_only_t` and thereby fix the build failure
* Fix `rmw_service_server_is_available` and ` rmw_destroy_wait_set_return` to use `RMW_RET_INVALID_ARGUMENT`
* Fix `rmw_create_node` to use `rmw_namespace_validation_result_string`